### PR TITLE
aurora not supported with RDS stop start

### DIFF
--- a/lib/cf_start_stop_environment.rb
+++ b/lib/cf_start_stop_environment.rb
@@ -259,6 +259,12 @@ module Base2
               return
             end
 
+            # RDS stop start does not support Aurora yet. Ignore if engine is aurora
+            if rds_instance.engine == 'aurora'
+              $log.info("RDS Instance #{instance_id} engine is aurora and cannot be stoped yet...")
+              return
+            end
+
             configuration = {
                 is_multi_az: rds_instance.multi_az
             }


### PR DESCRIPTION
stop command generates the following error when trying to stop Aurora
```
I, [2017-10-13T08:44:21.180375 #4500]  INFO -- : Stopping instance <Instance-Id>
/home/jenkins/.chefdk/gem/ruby/2.3.0/gems/cfn_manage-0.1.2/lib/cf_start_stop_environment.rb:72:in `eval': aurora DB instances are not eligible for stopping and starting. (Aws::RDS::Errors::InvalidParameterCombination)
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/aws-sdk-core-3.6.0/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `call'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/aws-sdk-core-3.6.0/lib/aws-sdk-core/plugins/idempotency_token.rb:17:in `call'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/aws-sdk-core-3.6.0/lib/aws-sdk-core/plugins/param_converter.rb:24:in `call'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/aws-sdk-core-3.6.0/lib/aws-sdk-core/plugins/response_paging.rb:10:in `call'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/aws-sdk-core-3.6.0/lib/seahorse/client/plugins/response_target.rb:23:in `call'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/aws-sdk-core-3.6.0/lib/seahorse/client/request.rb:70:in `send_request'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/aws-sdk-rds-1.5.0/lib/aws-sdk-rds/client.rb:12756:in `stop_db_instance'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/cfn_manage-0.1.2/lib/cf_start_stop_environment.rb:275:in `start_stop_rds'
	from (eval):1:in `block in do_stop_assets'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/cfn_manage-0.1.2/lib/cf_start_stop_environment.rb:72:in `eval'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/cfn_manage-0.1.2/lib/cf_start_stop_environment.rb:72:in `block in do_stop_assets'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/cfn_manage-0.1.2/lib/cf_start_stop_environment.rb:68:in `each'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/cfn_manage-0.1.2/lib/cf_start_stop_environment.rb:68:in `do_stop_assets'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/cfn_manage-0.1.2/lib/cf_start_stop_environment.rb:57:in `stop_environment'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/cfn_manage-0.1.2/bin/cfn_manage.rb:92:in `<top (required)>'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/cfn_manage-0.1.2/bin/cfn_manage:2:in `require_relative'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/gems/cfn_manage-0.1.2/bin/cfn_manage:2:in `<top (required)>'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/bin/cfn_manage:22:in `load'
	from /home/jenkins/.chefdk/gem/ruby/2.3.0/bin/cfn_manage:22:in `<main>'
```

Ignoring rds engine aurora until support is available