### PR TITLE
Feature/refactor and alarms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Created by .ignore support plugin (hsz.mobi)
 Gemfile.lock
 *.gem
+release.sh

--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@ Stop environment will
 - Stops RDS instances
 - If RDS instance is Multi-AZ, it is converted to single-az prior it
   is being stopped
+- Disable CloudWatch Alarm actions
 
 Start environment operation will
 
 - Set all ASG's size to what was prior stop operation
 - Starts ASG instances
 - If ASG instance was Mutli-AZ, it is converted back to Multi-AZ
-
+- Enable CloudWatch Alarm actions
 Metadata about environment, such as number of desired/max/min instances within ASG and MultiAZ property
 for rds instances, is stored in S3 bucket specified via `--source-bucket` switch or `SOURCE_BUCKET` environment
 variable. 
@@ -106,3 +107,10 @@ There are command line switch counter parts for all of the
 `SOURCE_BUCKET` as env var or `--source-bucket` as CLI switch
 
 `DRY_RUN` as env var (set to '1' to enable) or `--dry-run` as CLI switch
+
+## Release process
+
+ - Bump up version `gem install bump && bump [patch|minor|major]`
+ - Update timestamp in `cfn_manage.gemspec`
+ - Create and publish gem `gem build cfn_manage.gemspect && gem push cfn_manage-$VERSION.gem`
+ - Create release page on GitHub 

--- a/lib/alarm_start_stop_handler.rb
+++ b/lib/alarm_start_stop_handler.rb
@@ -1,0 +1,24 @@
+require_relative '../lib/aws_credentials'
+
+module Base2
+
+  class AlarmStartStopHandler
+
+    def initialize(alarm_id)
+      @alarm_id = alarm_id
+      $log.info("Start stop handler for alarm #{alarm_id}")
+    end
+
+    def start(configuration)
+      $log.info("Alarm #{@alarm_id} enabled")
+    end
+
+    def start(configuration)
+      $log.info("Alarm #{@alarm_id} disabled")
+      return nil
+    end
+
+
+  end
+
+end

--- a/lib/alarm_start_stop_handler.rb
+++ b/lib/alarm_start_stop_handler.rb
@@ -4,21 +4,36 @@ module Base2
 
   class AlarmStartStopHandler
 
-    def initialize(alarm_id)
-      @alarm_id = alarm_id
-      $log.info("Start stop handler for alarm #{alarm_id}")
+    def initialize(alarm_name)
+      @alarm_id = alarm_name
+      credentials = Base2::AWSCredentials.get_session_credentials("startstopalarm_#{@asg_name}")
+      @cwclient = Aws::CloudWatch::Client.new()
+      if credentials != nil
+        @cwclient = Aws::CloudWatch::Client.new(credentials: credentials)
+      end
+
+      @cwresource = Aws::CloudWatch::Resource.new(client: @cwclient)
+      @alarm = @cwresource.alarm(alarm_name)
     end
 
     def start(configuration)
-      $log.info("Alarm #{@alarm_id} enabled")
+      if @alarm.actions_enabled
+        $log.info("Alarm #{@alarm.alarm_arn} actions already enabled")
+        return
+      end
+      $log.info("Enabling alarm #{@alarm.alarm_arn}")
+      @alarm.enable_actions({})
     end
 
-    def start(configuration)
-      $log.info("Alarm #{@alarm_id} disabled")
-      return nil
+    def stop
+      if not @alarm.actions_enabled
+        $log.info("Alarm #{@alarm.alarm_arn} actions already disabled")
+        return {}
+      end
+      $log.info("Disabling actions on alarm #{@alarm.alarm_arn}")
+      @alarm.disable_actions({})
+      return {}
     end
-
-
   end
 
 end

--- a/lib/asg_start_stop_handler.rb
+++ b/lib/asg_start_stop_handler.rb
@@ -1,0 +1,69 @@
+require_relative '../lib/aws_credentials'
+
+module Base2
+
+  class AsgStartStopHandler
+
+    def initialize(asg_id)
+      @asg_name = asg_id
+
+      credentials = Base2::AWSCredentials.get_session_credentials("stopasg_#{@asg_name}")
+      @asg_client = Aws::AutoScaling::Client.new()
+      if credentials != nil
+        asg_client = Aws::AutoScaling::Client.new(credentials: credentials)
+      end
+
+      asg_details = asg_client.describe_auto_scaling_groups(
+          auto_scaling_group_names: [@asg_name]
+      )
+      if asg_details.auto_scaling_groups.size() == 0
+        raise "Couldn't find ASG #{@asg_name}"
+      end
+      @asg = asg_details.auto_scaling_groups[0]
+    end
+
+    def stop
+      # check if already stopped
+      if @asg.min_size == @asg.max_size and @asg.max_size == @asg.desired_capacity and @asg.min_size == 0
+        $log.info("ASG #{@asg_name} already stopped")
+        # nil and false configurations are not saved
+        return nil
+      else
+        # store asg configuration to S3
+        configuration = {
+            desired_capacity: @asg.desired_capacity,
+            min_size: @asg.min_size,
+            max_size: @asg.max_size
+        }
+
+        $log.info("Setting desired capacity to 0/0/0 for ASG #{@asg_name}")
+        # set asg configuration to 0/0/0
+        @asg_client.update_auto_scaling_group({
+            auto_scaling_group_name: @asg_name,
+            min_size: 0,
+            max_size: 0,
+            desired_capacity: 0
+        })
+        return configuration
+      end
+
+    end
+
+    def start(configuration)
+      if configuration.nil?
+        $log.warn("No configuration found for #{@asg_name}, skipping..")
+        return
+      end
+      $log.info("Starting ASG #{@asg_name} with following configuration\n#{configuration}")
+
+      # restore asg sizes
+      @asg_client.update_auto_scaling_group({
+          auto_scaling_group_name: @asg_name,
+          min_size: configuration['min_size'],
+          max_size: configuration['max_size'],
+          desired_capacity: configuration['desired_capacity']
+      })
+    end
+
+  end
+end

--- a/lib/asg_start_stop_handler.rb
+++ b/lib/asg_start_stop_handler.rb
@@ -10,10 +10,10 @@ module Base2
       credentials = Base2::AWSCredentials.get_session_credentials("stopasg_#{@asg_name}")
       @asg_client = Aws::AutoScaling::Client.new()
       if credentials != nil
-        asg_client = Aws::AutoScaling::Client.new(credentials: credentials)
+        @asg_client = Aws::AutoScaling::Client.new(credentials: credentials)
       end
 
-      asg_details = asg_client.describe_auto_scaling_groups(
+      asg_details = @asg_client.describe_auto_scaling_groups(
           auto_scaling_group_names: [@asg_name]
       )
       if asg_details.auto_scaling_groups.size() == 0
@@ -36,10 +36,11 @@ module Base2
             max_size: @asg.max_size
         }
 
-        $log.info("Setting desired capacity to 0/0/0 for ASG #{@asg_name}")
+        $log.info("Setting desired capacity to 0/0/0 for ASG #{@asg.auto_scaling_group_name}A")
         # set asg configuration to 0/0/0
+        puts @asg.auto_scaling_group_name
         @asg_client.update_auto_scaling_group({
-            auto_scaling_group_name: @asg_name,
+            auto_scaling_group_name: "#{@asg.auto_scaling_group_name}",
             min_size: 0,
             max_size: 0,
             desired_capacity: 0

--- a/lib/cf_start_stop_environment.rb
+++ b/lib/cf_start_stop_environment.rb
@@ -3,6 +3,7 @@ require_relative '../lib/cf_common'
 require_relative '../lib/aws_credentials'
 require 'json'
 require 'yaml'
+require_relative '../lib/start_stop_handler_factory'
 
 module Base2
   module CloudFormation
@@ -14,19 +15,12 @@ module Base2
       @s3_bucket = nil
       @credentials = nil
       @dry_run = false
-      @@supported_start_stop_resources = {
-          'AWS::AutoScaling::AutoScalingGroup' => 'start_stop_asg',
-          'AWS::RDS::DBInstance' => 'start_stop_rds',
-          'AWS::EC2::Instance' => 'start_stop_ec2'
-      }
 
       @@resource_start_priorities = {
           'AWS::RDS::DBInstance' => '100',
           'AWS::AutoScaling::AutoScalingGroup' => '200',
           'AWS::EC2::Instance' => '200'
       }
-
-      @environment_resources = nil
 
       def initialize()
         @environment_resources = []
@@ -35,7 +29,7 @@ module Base2
         @cf_client = Aws::CloudFormation::Client.new()
         @credentials = Base2::AWSCredentials.get_session_credentials('start_stop_environment')
         if not @credentials.nil?
-          @cf_client =  Aws::CloudFormation::Client.new(credentials: @credentials)
+          @cf_client = Aws::CloudFormation::Client.new(credentials: @credentials)
         end
         @dry_run = (ENV.key?('DRY_RUN') and ENV['DRY_RUN'] == '1')
       end
@@ -45,7 +39,7 @@ module Base2
         $log.info("Starting environment #{stack_name}")
         Common.visit_stack(@cf_client, stack_name, method(:collect_resources), true)
         do_start_assets
-        configuration = {stack_running: true}
+        configuration = { stack_running: true }
         save_item_configuration("environment-data/stack-data/#{stack_name}", configuration) unless @dry_run
         $log.info("Environment #{stack_name} started")
       end
@@ -55,7 +49,7 @@ module Base2
         $log.info("Stopping environment #{stack_name}")
         Common.visit_stack(@cf_client, stack_name, method(:collect_resources), true)
         do_stop_assets
-        configuration = {stack_running: false}
+        configuration = { stack_running: false }
         save_item_configuration("environment-data/stack-data/#{stack_name}", configuration) unless @dry_run
         $log.info("Environment #{stack_name} stopped")
       end
@@ -63,13 +57,17 @@ module Base2
 
       def do_stop_assets
         # sort start resource by priority
-        @environment_resources = @environment_resources.sort_by { |k| k[:priority]}.reverse
+        @environment_resources = @environment_resources.sort_by { |k| k[:priority] }.reverse
 
         @environment_resources.each do |resource|
           $log.info("Stopping resource #{resource[:id]}")
           # just print out information if running a dry run, otherwise start assets
           if not @dry_run
-            eval "self.#{resource[:method]}('stop','#{resource[:id]}')"
+            configuration = resource[:handler].stop()
+            if configuration.class == Hash
+              s3_prefix = "environment_data/resource/#{resource[:id]}"
+              save_item_configuration(s3_prefix, configuration)
+            end
           else
             $log.info("Dry run enabled, skipping stop start\nFollowing resource would be stopped: #{resource[:id]}")
             $log.debug("Resource type: #{resource[:type]}\n\n")
@@ -77,16 +75,20 @@ module Base2
         end
       end
 
-
       def do_start_assets
         # sort start resource by priority
-        @environment_resources = @environment_resources.sort_by { |k| k[:priority]}
+        @environment_resources = @environment_resources.sort_by { |k| k[:priority] }
 
         @environment_resources.each do |resource|
           $log.info("Starting resource #{resource[:id]}")
           # just print out information if running a dry run, otherwise start assets
           if not @dry_run
-            eval "self.#{resource[:method]}('start','#{resource[:id]}')"
+            # read configuration
+            s3_prefix = "environment_data/resource/#{resource[:id]}"
+            configuration = get_object_configuration(s3_prefix)
+
+            # start
+            resource[:handler].start(configuration)
           else
             $log.info("Dry run enabled, skipping actual start\nFollowing resource would be started: #{resource[:id]}")
             $log.debug("Resource type: #{resource[:type]}\n\n")
@@ -97,234 +99,27 @@ module Base2
       def collect_resources(stack_name)
         resrouces = @cf_client.describe_stack_resources(stack_name: stack_name)
         resrouces['stack_resources'].each do |resource|
-          if @@supported_start_stop_resources.key?(resource['resource_type'])
-            method_name = @@supported_start_stop_resources[resource['resource_type']]
+          start_stop_handler = nil
+          begin
+            start_stop_handler = Base2::StartStopHandlerFactory.get_start_stop_handler(
+                resource['resource_type'],
+                resource['physical_resource_id']
+            )
+          rescue Exception => e
+            $log.error("Error creating start-stop handler for resource of type #{resource['resource_type']}" +
+                "and with id #{resource['physical_resource_id']}:#{e}")
+          end
+          if not start_stop_handler.nil?
             resource_id = resource['physical_resource_id']
-
             @environment_resources << {
                 id: resource_id,
                 priority: @@resource_start_priorities[resource['resource_type']],
-                method: method_name,
+                handler: start_stop_handler,
                 type: resource['resource_type']
             }
           end
         end
       end
-
-      def start_stop_ec2(cmd, instance_id)
-        credentials = Base2::AWSCredentials.get_session_credentials("stoprun_#{instance_id}")
-        ec2_client = Aws::EC2::Client.new(credentials: credentials)
-
-        begin
-          instance = Aws::EC2::Resource.new(client: ec2_client).instance(instance_id)
-
-          if cmd == 'stop'
-            if %w(stopped stopping).include?(instance.state.name)
-              $log.info("Instance #{instance_id} already stopping or stopped")
-              return
-            end
-            $log.info("Stopping instance #{instance_id}")
-            instance.stop()
-          end
-
-          if cmd == 'start'
-            if %w(running).include?(instance.state.name)
-              $log.info("Instance #{instance_id} already running")
-              return
-            end
-            $log.info("Starting instance #{instance_id}")
-            instance.start()
-          end
-        rescue => e
-          $log.error("Failed execution #{cmd} on instance #{instance_id}:\n#{e}")
-        end
-
-      end
-
-      def start_stop_asg(cmd, asg_name)
-
-        # read asg data
-        credentials = Base2::AWSCredentials.get_session_credentials("stopasg_#{asg_name}")
-        asg_client = Aws::AutoScaling::Client.new()
-        if credentials != nil
-          asg_client = Aws::AutoScaling::Client.new(credentials: credentials)
-        end
-
-        asg_details = asg_client.describe_auto_scaling_groups(
-            auto_scaling_group_names: [asg_name]
-        )
-        if asg_details.auto_scaling_groups.size() == 0
-          raise "Couldn't find ASG #{asg_name}"
-        end
-        asg = asg_details.auto_scaling_groups[0]
-        s3_prefix = "environment-data/asg-data/#{asg_name}"
-        case cmd
-          when 'start'
-
-            # retrieve asg params from s3
-            configuration = self.get_object_configuration(s3_prefix)
-            if configuration.nil?
-              $log.warn("No configuration found for #{asg_name}, skipping..")
-              return
-            end
-            $log.info("Starting ASG #{asg_name} with following configuration\n#{configuration}")
-
-            # restore asg sizes
-            asg_client.update_auto_scaling_group({
-                auto_scaling_group_name: asg_name,
-                min_size: configuration['min_size'],
-                max_size: configuration['max_size'],
-                desired_capacity: configuration['desired_capacity']
-            })
-
-          when 'stop'
-            # check if already stopped
-            if asg.min_size == asg.max_size and asg.max_size == asg.desired_capacity and asg.min_size == 0
-              $log.info("ASG #{asg_name} already stopped")
-            else
-              # store asg configuration to S3
-              configuration = {
-                  desired_capacity: asg.desired_capacity,
-                  min_size: asg.min_size,
-                  max_size: asg.max_size
-              }
-              self.save_item_configuration(s3_prefix, configuration)
-
-              $log.info("Setting desired capacity to 0/0/0 for ASG #{asg_name}")
-              # set asg configuration to 0/0/0
-              asg_client.update_auto_scaling_group({
-                  auto_scaling_group_name: asg_name,
-                  min_size: 0,
-                  max_size: 0,
-                  desired_capacity: 0
-              })
-            end
-          # TODO wait for operation to complete (optionally)
-        end
-
-
-      end
-
-      def start_stop_rds(cmd, instance_id)
-        credentials = Base2::AWSCredentials.get_session_credentials("startstoprds_#{instance_id}")
-        rds_client = Aws::RDS::Client.new()
-        if credentials != nil
-          rds_client = Aws::RDS::Client.new(credentials: credentials)
-        end
-        rds = Aws::RDS::Resource.new(client: rds_client)
-        rds_instance = rds.db_instance(instance_id)
-        s3_prefix = "environment-data/rds-data/#{instance_id}"
-        case cmd
-          when 'start'
-            if rds_instance.db_instance_status == 'available'
-              $log.info("RDS Instance #{instance_id} is already in available state")
-              return
-            end
-
-            #retrieve multi-az data from S3
-            configuration = get_object_configuration(s3_prefix)
-            if configuration.nil?
-              $log.warning("No configuration found for #{rds_instance}, skipping..")
-              return
-            end
-
-            # start rds instance
-            if rds_instance.db_instance_status == 'stopped'
-              $log.info("Starting db instance #{instance_id}")
-              rds_client.start_db_instance({ db_instance_identifier: instance_id })
-
-              # wait instance to become available
-              $log.info("Waiting db instance to become available #{instance_id}")
-              wait_rds_instance_states(rds_client, instance_id, %w(starting available))
-            else
-              wait_rds_instance_states(rds_client, instance_id, %w(available))
-            end
-
-            # convert rds instance to mutli-az if required
-            if configuration['is_multi_az']
-              $log.info("Converting to Multi-AZ instance after start (instance #{instance_id})")
-              set_rds_instance_multi_az(rds_instance, true)
-            end
-
-          when 'stop'
-            # store mutli-az data to S3
-            if rds_instance.db_instance_status != 'available'
-              $log.warn("RDS Instance #{instance_id} not in available state, and thus can not be stopped")
-              $log.warn("RDS Instance #{instance_id} state: #{rds_instance.db_instance_status}")
-              return
-            end
-
-            if rds_instance.db_instance_status == 'stopped'
-              $log.info("RDS Instance #{instance_id} is already stopped")
-              return
-            end
-
-            # RDS stop start does not support Aurora yet. Ignore if engine is aurora
-            if rds_instance.engine == 'aurora'
-              $log.info("RDS Instance #{instance_id} engine is aurora and cannot be stoped yet...")
-              return
-            end
-
-            configuration = {
-                is_multi_az: rds_instance.multi_az
-            }
-            save_item_configuration(s3_prefix, configuration)
-
-            #check if mutli-az RDS. if so, convert to single-az
-            if rds_instance.multi_az
-              $log.info("Converting to Non-Multi-AZ instance before stop (instance #{instance_id}")
-              set_rds_instance_multi_az(rds_instance, false)
-            end
-
-            # stop rds instance and wait for it to be fully stopped
-            $log.info("Stopping instance #{instance_id}")
-            rds_client.stop_db_instance({ db_instance_identifier: instance_id })
-            $log.info("Waiting db instance to be stopped #{instance_id}")
-            wait_rds_instance_states(rds_client, instance_id, %w(stopping stopped))
-        end
-      end
-
-      def set_rds_instance_multi_az(rds_instance, multi_az)
-        if rds_instance.multi_az == multi_az
-          $log.info("Rds instance #{rds_instance.db_instance_identifier} already multi-az=#{multi_az}")
-          return
-        end
-        rds_instance.modify({ multi_az: multi_az, apply_immediately: true })
-        # allow half an hour for instance to be converted
-        wait_states = %w(modifying available)
-        wait_rds_instance_states(rds_instance, wait_states)
-      end
-
-      def wait_rds_instance_states(client, rds_instance_id, wait_states)
-        wait_states.each do |state|
-          # reached state must be steady, at least a minute. Modifying an instance to/from MultiAZ can't be shorter
-          # than 40 seconds, hence steady count is 4
-          state_count = 0
-          steady_count = 4
-          attempts = 0
-          rds = Aws::RDS::Resource.new(client: client)
-          until attempts == (max_attempts = 60*6) do
-            instance = rds.db_instance(rds_instance_id)
-            $log.info("Instance #{instance.db_instance_identifier} state: #{instance.db_instance_status}, waiting for #{state}")
-
-            if instance.db_instance_status == "#{state}"
-              state_count = state_count + 1
-              $log.info("#{state_count}/#{steady_count}")
-            else
-              state_count = 0
-            end
-            break if state_count == steady_count
-            attempts = attempts + 1
-            sleep(15)
-          end
-
-          if attempts == max_attempts
-            $log.error("RDS Database Instance #{rds_instance_id} did not enter #{state} state, however continuing operations...")
-          end
-
-        end
-      end
-
 
       def get_object_configuration(s3_prefix)
         configuration = nil
@@ -358,6 +153,9 @@ module Base2
           })
         end
       end
+
+      private :do_stop_assets, :do_start_assets, :collect_resources, :get_object_configuration, :save_item_configuration
+
     end
   end
 end

--- a/lib/cf_start_stop_environment.rb
+++ b/lib/cf_start_stop_environment.rb
@@ -19,7 +19,8 @@ module Base2
       @@resource_start_priorities = {
           'AWS::RDS::DBInstance' => '100',
           'AWS::AutoScaling::AutoScalingGroup' => '200',
-          'AWS::EC2::Instance' => '200'
+          'AWS::EC2::Instance' => '200',
+          'AWS::CloudWatch::Alarm' => '300'
       }
 
       def initialize()

--- a/lib/ec2_start_stop_handler.rb
+++ b/lib/ec2_start_stop_handler.rb
@@ -13,7 +13,7 @@ module Base2
       @instance_id = instance_id
     end
 
-    def start
+    def start(configuration)
       if %w(running).include?(@instance.state.name)
         $log.info("Instance #{@instance_id} already running")
         return
@@ -23,12 +23,12 @@ module Base2
     end
 
     def stop
-      if %w(stopped stopping).include?(@instance_id.state.name)
+      if %w(stopped stopping).include?(@instance.state.name)
         $log.info("Instance #{@instance_id} already stopping or stopped")
         return
       end
       $log.info("Stopping instance #{@instance_id}")
-      instance.stop()
+      @instance.stop()
 
       # empty configuration for ec2 instances
       return {}

--- a/lib/ec2_start_stop_handler.rb
+++ b/lib/ec2_start_stop_handler.rb
@@ -1,0 +1,41 @@
+require_relative '../lib/aws_credentials'
+
+module Base2
+
+  class Ec2StartStopHandler
+
+    @instance
+
+    def initialize(instance_id)
+      credentials = Base2::AWSCredentials.get_session_credentials("stoprun_#{instance_id}")
+      ec2_client = Aws::EC2::Client.new(credentials: credentials)
+      @instance = Aws::EC2::Resource.new(client: ec2_client).instance(instance_id)
+      @instance_id = instance_id
+    end
+
+    def start
+      if %w(running).include?(@instance.state.name)
+        $log.info("Instance #{@instance_id} already running")
+        return
+      end
+      $log.info("Starting instance #{@instance_id}")
+      @instance.start()
+    end
+
+    def stop
+      if %w(stopped stopping).include?(@instance_id.state.name)
+        $log.info("Instance #{@instance_id} already stopping or stopped")
+        return
+      end
+      $log.info("Stopping instance #{@instance_id}")
+      instance.stop()
+
+      # empty configuration for ec2 instances
+      return {}
+    end
+
+
+
+
+  end
+end

--- a/lib/rds_start_stop_handler.rb
+++ b/lib/rds_start_stop_handler.rb
@@ -1,0 +1,128 @@
+require_relative '../lib/aws_credentials'
+
+module Base2
+
+  class RdsStartStopHandler
+
+    def initialize(instance_id)
+      @instance_id = instance_id
+
+      credentials = Base2::AWSCredentials.get_session_credentials("startstoprds_#{instance_id}")
+      @rds_client = Aws::RDS::Client.new()
+      if credentials != nil
+        @rds_client = Aws::RDS::Client.new(credentials: credentials)
+      end
+      rds = Aws::RDS::Resource.new(client: @rds_client)
+      @rds_instance = rds.db_instance(instance_id)
+
+    end
+
+    def start(configuration)
+      if @rds_instance.db_instance_status == 'available'
+        $log.info("RDS Instance #{@instance_id} is already in available state")
+        return
+      end
+
+      # start rds instance
+      if @rds_instance.db_instance_status == 'stopped'
+        $log.info("Starting db instance #{@instance_id}")
+        @rds_client.start_db_instance({ db_instance_identifier: @instance_id })
+
+        # wait instance to become available
+        $log.info("Waiting db instance to become available #{@instance_id}")
+        wait_rds_instance_states( %w(starting available))
+      else
+        wait_rds_instance_states( %w(available))
+      end
+
+      # convert rds instance to mutli-az if required
+      if configuration['is_multi_az']
+        $log.info("Converting to Multi-AZ instance after start (instance #{@instance_id})")
+        set_rds_instance_multi_az( true)
+      end
+    end
+
+    def stop
+
+      configuration = {
+          is_multi_az: @rds_instance.multi_az
+      }
+      # RDS stop start does not support Aurora yet. Ignore if engine is aurora
+      if @rds_instance.engine == 'aurora' or @rds_instance.engine.include?('sqlserver')
+         $log.info("RDS Instance #{instance_id} engine is aurora and cannot be stoped yet...")
+         return configuration
+      end
+
+      # check if available
+      if @rds_instance.db_instance_status != 'available'
+        $log.warn("RDS Instance #{@instance_id} not in available state, and thus can not be stopped")
+        $log.warn("RDS Instance #{@instance_id} state: #{@rds_instance.db_instance_status}")
+        return configuration
+      end
+
+      # check if already stopped
+      if @rds_instance.db_instance_status == 'stopped'
+        $log.info("RDS Instance #{@instance_id} is already stopped")
+        return configuration
+      end
+
+      #check if mutli-az RDS. if so, convert to single-az
+      if @rds_instance.multi_az
+        $log.info("Converting to Non-Multi-AZ instance before stop (instance #{@instance_id}")
+        set_rds_instance_multi_az(false)
+      end
+
+      # stop rds instance and wait for it to be fully stopped
+      $log.info("Stopping instance #{@instance_id}")
+      @rds_client.stop_db_instance({ db_instance_identifier: @instance_id })
+      $log.info("Waiting db instance to be stopped #{@instance_id}")
+      wait_rds_instance_states(%w(stopping stopped))
+
+      return configuration
+    end
+
+    def set_rds_instance_multi_az(multi_az)
+      if @rds_instance.multi_az == multi_az
+        $log.info("Rds instance #{@rds_instance.db_instance_identifier} already multi-az=#{multi_az}")
+        return
+      end
+      @rds_instance.modify({ multi_az: multi_az, apply_immediately: true })
+      # allow half an hour for instance to be converted
+      wait_states = %w(modifying available)
+      self.wait_rds_instance_states( wait_states)
+    end
+
+    def wait_rds_instance_states(wait_states)
+      wait_states.each do |state|
+        # reached state must be steady, at least a minute. Modifying an instance to/from MultiAZ can't be shorter
+        # than 40 seconds, hence steady count is 4
+        state_count = 0
+        steady_count = 4
+        attempts = 0
+        rds = Aws::RDS::Resource.new(client: @rds_client)
+        until attempts == (max_attempts = 60*6) do
+          instance = rds.db_instance(@instance_id)
+          $log.info("Instance #{instance.db_instance_identifier} state: #{instance.db_instance_status}, waiting for #{state}")
+
+          if instance.db_instance_status == "#{state}"
+            state_count = state_count + 1
+            $log.info("#{state_count}/#{steady_count}")
+          else
+            state_count = 0
+          end
+          break if state_count == steady_count
+          attempts = attempts + 1
+          sleep(15)
+        end
+
+        if attempts == max_attempts
+          $log.error("RDS Database Instance #{@instance_id} did not enter #{state} state, however continuing operations...")
+        end
+      end
+    end
+
+    private :set_rds_instance_multi_az, :wait_rds_instance_states
+
+  end
+
+end

--- a/lib/rds_start_stop_handler.rb
+++ b/lib/rds_start_stop_handler.rb
@@ -48,7 +48,7 @@ module Base2
           is_multi_az: @rds_instance.multi_az
       }
       # RDS stop start does not support Aurora yet. Ignore if engine is aurora
-      if @rds_instance.engine == 'aurora' or @rds_instance.engine.include?('sqlserver')
+      if @rds_instance.engine == 'aurora'
          $log.info("RDS Instance #{instance_id} engine is aurora and cannot be stoped yet...")
          return configuration
       end

--- a/lib/start_stop_handler_factory.rb
+++ b/lib/start_stop_handler_factory.rb
@@ -1,0 +1,32 @@
+require_relative '../lib/asg_start_stop_handler'
+require_relative '../lib/ec2_start_stop_handler'
+require_relative '../lib/rds_start_stop_handler'
+require_relative '../lib/alarm_start_stop_handler'
+
+module Base2
+
+  class StartStopHandlerFactory
+
+    #   Factory method to get start/stop handler based on CloudFormation
+    # resource type. If resource_id passed in does not exist, it is
+    # very likely that exception will be raised
+    def self.get_start_stop_handler(resource_type, resource_id)
+      case resource_type
+        when 'AWS::AutoScaling::AutoScalingGroup'
+          return Base2::AsgStartStopHandler.new(resource_id)
+
+        when 'AWS::EC2::Instance'
+          return Base2::Ec2StartStopHandler.new(resource_id)
+
+        when 'AWS::RDS::DBInstance'
+          return Base2::RdsStartStopHandler.new(resource_id)
+
+        when 'AWS::AutoScaling::AutoScalingGroup'
+          return Base2::AsgStartStopHandler.new(resource_id)
+
+        else
+          return nil
+      end
+    end
+  end
+end

--- a/lib/start_stop_handler_factory.rb
+++ b/lib/start_stop_handler_factory.rb
@@ -21,8 +21,8 @@ module Base2
         when 'AWS::RDS::DBInstance'
           return Base2::RdsStartStopHandler.new(resource_id)
 
-        when 'AWS::AutoScaling::AutoScalingGroup'
-          return Base2::AsgStartStopHandler.new(resource_id)
+        when 'AWS::CloudWatch::Alarm'
+          return Base2::AlarmStartStopHandler.new(resource_id)
 
         else
           return nil


### PR DESCRIPTION
## Change
###  Refactor

Major code refactoring. Rather than having all resource handlers in single class, start/stop handlers are produced via factory pattern. Input to factory is CloudFormation resource type. 

### Support for cloudwatch alarms

CloudWatch Alarms will have their actions enabled or disabled in case of start (stopping) CloudFormation stack. 

## Testing

### As Issue #6 is still under development, this has been tested manually, on CloudFormation stack with all resources. 
