### PR TITLE
v0.2.2-5

### DIFF
--- a/cfn_manage.gemspec
+++ b/cfn_manage.gemspec
@@ -2,7 +2,7 @@ require 'rake'
 
 Gem::Specification.new do |s|
   s.name        = 'cfn_manage'
-  s.version     = '0.2.2'
+  s.version     = '0.2.3'
   s.date        = '2017-11-28'
   s.summary     = 'Manage AWS Cloud Formation stacks'
   s.description = ''

--- a/cfn_manage.gemspec
+++ b/cfn_manage.gemspec
@@ -2,7 +2,7 @@ require 'rake'
 
 Gem::Specification.new do |s|
   s.name        = 'cfn_manage'
-  s.version     = '0.2.3'
+  s.version     = '0.2.4'
   s.date        = '2017-11-28'
   s.summary     = 'Manage AWS Cloud Formation stacks'
   s.description = ''

--- a/cfn_manage.gemspec
+++ b/cfn_manage.gemspec
@@ -2,7 +2,7 @@ require 'rake'
 
 Gem::Specification.new do |s|
   s.name        = 'cfn_manage'
-  s.version     = '0.2.4'
+  s.version     = '0.2.5'
   s.date        = '2017-11-28'
   s.summary     = 'Manage AWS Cloud Formation stacks'
   s.description = ''

--- a/lib/alarm_start_stop_handler.rb
+++ b/lib/alarm_start_stop_handler.rb
@@ -7,9 +7,9 @@ module Base2
     def initialize(alarm_name)
       @alarm_id = alarm_name
       credentials = Base2::AWSCredentials.get_session_credentials("startstopalarm_#{@asg_name}")
-      @cwclient = Aws::CloudWatch::Client.new()
+      @cwclient = Aws::CloudWatch::Client.new(retry_limit: 20)
       if credentials != nil
-        @cwclient = Aws::CloudWatch::Client.new(credentials: credentials)
+        @cwclient = Aws::CloudWatch::Client.new(credentials: credentials, retry_limit: 20)
       end
 
       @cwresource = Aws::CloudWatch::Resource.new(client: @cwclient)

--- a/lib/asg_start_stop_handler.rb
+++ b/lib/asg_start_stop_handler.rb
@@ -8,9 +8,9 @@ module Base2
       @asg_name = asg_id
 
       credentials = Base2::AWSCredentials.get_session_credentials("stopasg_#{@asg_name}")
-      @asg_client = Aws::AutoScaling::Client.new()
+      @asg_client = Aws::AutoScaling::Client.new(retry_limit: 20)
       if credentials != nil
-        @asg_client = Aws::AutoScaling::Client.new(credentials: credentials)
+        @asg_client = Aws::AutoScaling::Client.new(credentials: credentials, retry_limit: 20)
       end
 
       asg_details = @asg_client.describe_auto_scaling_groups(

--- a/lib/ec2_start_stop_handler.rb
+++ b/lib/ec2_start_stop_handler.rb
@@ -8,8 +8,8 @@ module Base2
 
     def initialize(instance_id)
       credentials = Base2::AWSCredentials.get_session_credentials("stoprun_#{instance_id}")
-      ec2_client = Aws::EC2::Client.new(credentials: credentials)
-      @instance = Aws::EC2::Resource.new(client: ec2_client).instance(instance_id)
+      ec2_client = Aws::EC2::Client.new(credentials: credentials, retry_limit: 20)
+      @instance = Aws::EC2::Resource.new(client: ec2_client, retry_limit: 20).instance(instance_id)
       @instance_id = instance_id
     end
 

--- a/lib/rds_start_stop_handler.rb
+++ b/lib/rds_start_stop_handler.rb
@@ -20,7 +20,6 @@ module Base2
     def start(configuration)
       if @rds_instance.db_instance_status == 'available'
         $log.info("RDS Instance #{@instance_id} is already in available state")
-        return
       end
 
       # start rds instance

--- a/lib/rds_start_stop_handler.rb
+++ b/lib/rds_start_stop_handler.rb
@@ -8,9 +8,9 @@ module Base2
       @instance_id = instance_id
 
       credentials = Base2::AWSCredentials.get_session_credentials("startstoprds_#{instance_id}")
-      @rds_client = Aws::RDS::Client.new()
+      @rds_client = Aws::RDS::Client.new(retry_limit: 20)
       if credentials != nil
-        @rds_client = Aws::RDS::Client.new(credentials: credentials)
+        @rds_client = Aws::RDS::Client.new(credentials: credentials, retry_limit: 20)
       end
       rds = Aws::RDS::Resource.new(client: @rds_client)
       @rds_instance = rds.db_instance(instance_id)


### PR DESCRIPTION
Gem versions 
- v0.2.2
- v0.2.4
- v0.2.5

Addressing following issues

# Retry count
Every client in start/stop handlers has increased retry count to 20 from default of 3. 

# RDS corrupt configuration
In case RDS instance is running, but configuration states it's MultiAZ, we should allow start script to convert instance to MultiAZ, aligning state of the stack with stack configuration. 

